### PR TITLE
Apply stock antenna bases masses from newComms

### DIFF
--- a/GameData/RealAntennas/RealAntennas.cfg
+++ b/GameData/RealAntennas/RealAntennas.cfg
@@ -1,5 +1,6 @@
 @PART[SurfAntenna]:HAS[@MODULE[ModuleDataTransmitter]]
 {
+    @mass = 0.001
     !MODULE[ModuleDataTransmitter],* {}
     MODULE
     {
@@ -37,6 +38,7 @@
 @PART[HighGainAntenna]:HAS[@MODULE[ModuleDataTransmitter]]
 {
     @title = 1.22 m Retractable Parabolic Antenna
+    @mass = 0.010
     !MODULE[ModuleDataTransmitter],* {}
     MODULE
     {
@@ -48,6 +50,7 @@
 @PART[HighGainAntenna5]:HAS[@MODULE[ModuleDataTransmitter]]
 {
     @title = 0.5 m Retractable Parabolic Antenna
+    @mass = 0.002
     !MODULE[ModuleDataTransmitter],* {}
     MODULE
     {
@@ -59,6 +62,7 @@
 @PART[RelayAntenna5]:HAS[@MODULE[ModuleDataTransmitter]]
 {
     @title = 1 m Parabolic Antenna
+    @mass = 0.004
     !MODULE[ModuleDataTransmitter],* {}
     MODULE
     {
@@ -72,6 +76,7 @@
 @PART[RelayAntenna50]:HAS[@MODULE[ModuleDataTransmitter]]
 {
     @title = 2 m Parabolic Antenna
+    @mass = 0.0159
     !MODULE[ModuleDataTransmitter],* {}
     MODULE
     {
@@ -86,6 +91,7 @@
     %rescaleFactor:NEEDS[ReStock] = 1.3115
     
     @title = 4 m Parabolic Antenna
+    @mass = 0.0633
     
     !MODULE[ModuleDataTransmitter],* {}
     MODULE


### PR DESCRIPTION
lower than "standard" RO to avoid double-charging for
transmitter mass