### PR TITLE
Fix memory leak as reported by KSPCF

### DIFF
--- a/src/RealAntennasProject/RealAntennasUI.cs
+++ b/src/RealAntennasProject/RealAntennasUI.cs
@@ -30,6 +30,20 @@ namespace RealAntennas
             GameEvents.onGUIApplicationLauncherReady.Remove(OnGuiAppLauncherReady);
             if (button != null)
                 ApplicationLauncher.Instance.RemoveModApplication(button);
+
+            // Mitigate memory leakage
+            if (HighLogic.CurrentGame.Parameters.CustomParams<RAParameters>().performanceUI)
+            {
+                try
+                {
+                    GameEvents.onGameSceneLoadRequested.Remove(OnSceneChange);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"{modName} failed to remove OnSceneChange callback");
+                    Debug.LogException(ex);
+                }
+            }
         }
 
         public void OnMapExit()


### PR DESCRIPTION
This should fix the KSPCF complain of RA memory leak that looks like
```
[LOG 18:15:46.868] [KSPCF:MemoryLeaks] A destroyed RealAntennas:RealAntennasUI instance is owning a onGameSceneLoadRequested GameEvents callback. No action has been taken, but unless this mod is relying on this pattern, this is likely a memory leak.
```
Same as #83 
Briefly tested with a minimum KSP 1.12.3 install, the memory leak complain is gone.